### PR TITLE
Add under-construction banner to presentations, events, and engagemen…

### DIFF
--- a/src/components/presentations/EngagementPresentationPage.astro
+++ b/src/components/presentations/EngagementPresentationPage.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Badge from '../ui/Badge.astro';
 import Button from '../ui/Button.astro';
+import UnderConstructionBanner from '../ui/UnderConstructionBanner.astro';
 import { render, type CollectionEntry } from 'astro:content';
 import { getResourceIcon } from '@/lib/engagementPresentations';
 
@@ -14,6 +15,9 @@ export interface Props {
 
 const { engagement, event, presentation, canonicalUrl } = Astro.props;
 const { Content } = await render(engagement);
+
+const eventYear = event?.data.startDate.getFullYear();
+const showBanner = eventYear !== 2026 && !presentation?.data.validated;
 
 const displayTitle = engagement.data.sessionTitle || engagement.data.title;
 const eventTitle = event?.data.title || engagement.data.eventSlug;
@@ -81,6 +85,8 @@ const resourceLinks = engagement.data.links.length > 0
             </div>
         </div>
     </section>
+
+    <UnderConstructionBanner show={showBanner} />
 
     <section class="section">
         <div class="container">

--- a/src/components/ui/UnderConstructionBanner.astro
+++ b/src/components/ui/UnderConstructionBanner.astro
@@ -1,0 +1,54 @@
+---
+interface Props {
+    show?: boolean;
+}
+
+const { show = true } = Astro.props;
+---
+
+{show && (
+    <aside class="construction-banner" role="note" aria-label="Work in progress notice">
+        <div class="banner-inner">
+            <span class="banner-icon" aria-hidden="true">🚧</span>
+            <p>
+                <strong>Work in Progress</strong> — This site is actively being updated.
+                Some details may be inaccurate and images may be missing while content is validated.
+            </p>
+        </div>
+    </aside>
+)}
+
+<style>
+    .construction-banner {
+        background-color: #fef9c3;
+        border-top: 1px solid #fde047;
+        border-bottom: 1px solid #fde047;
+        padding: 0.5rem 0;
+    }
+
+    .banner-inner {
+        max-width: var(--container-max, 1280px);
+        margin: 0 auto;
+        padding: 0 var(--spacing-6, 1.5rem);
+        display: flex;
+        align-items: center;
+        gap: 0.625rem;
+    }
+
+    .banner-icon {
+        flex-shrink: 0;
+        font-size: 1rem;
+        line-height: 1;
+    }
+
+    .construction-banner p {
+        margin: 0;
+        font-size: var(--font-size-sm, 0.875rem);
+        color: #713f12;
+        line-height: 1.4;
+    }
+
+    .construction-banner strong {
+        color: #422006;
+    }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -46,6 +46,9 @@ const presentations = defineCollection({
         // Status
         status: z.enum(['active', 'retired', 'in-development']).default('active'),
         featured: z.boolean().default(false),
+
+        // Set to true once content has been reviewed and confirmed accurate
+        validated: z.boolean().optional().default(false),
     }),
 });
 
@@ -98,6 +101,9 @@ const events = defineCollection({
 
         // Status
         featured: z.boolean().default(false),
+
+        // Set to true once content has been reviewed and confirmed accurate
+        validated: z.boolean().optional().default(false),
 
         // Media
         heroImage: z.string().optional(),

--- a/src/pages/presentations/[slug].astro
+++ b/src/pages/presentations/[slug].astro
@@ -5,6 +5,7 @@ import Button from '../../components/ui/Button.astro';
 import TabNav from '../../components/ui/TabNav.astro';
 import TabSyncScript from '../../components/ui/TabSyncScript.astro';
 import EventCard from '../../components/cards/EventCard.astro';
+import UnderConstructionBanner from '../../components/ui/UnderConstructionBanner.astro';
 import { getCollection, render } from 'astro:content';
 import { marked } from 'marked';
 
@@ -130,6 +131,8 @@ const statusVariants: Record<string, 'primary' | 'secondary' | 'outline' | 'succ
             </div>
         </div>
     </section>
+
+    <UnderConstructionBanner show={!presentation.data.validated} />
 
     <!-- Tab Navigation -->
     <div class="tabs-container">

--- a/src/pages/presentations/index.astro
+++ b/src/pages/presentations/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import PageHeader from '../../components/ui/PageHeader.astro';
 import PresentationCard from '../../components/cards/PresentationCard.astro';
+import UnderConstructionBanner from '../../components/ui/UnderConstructionBanner.astro';
 import { getCollection } from 'astro:content';
 
 // Get all active presentations
@@ -33,7 +34,7 @@ const presentationTypes = [...new Set(presentations.map(p => p.data.type))];
         <p>Explore my collection of talks, workshops, and presentations</p>
     </PageHeader>
 
-    <section class="section">
+    <UnderConstructionBanner />
         <div class="container">
             <!-- Filter Controls -->
             {presentationTypes.length > 1 && (

--- a/src/pages/speaking/[slug].astro
+++ b/src/pages/speaking/[slug].astro
@@ -5,6 +5,7 @@ import Button from '../../components/ui/Button.astro';
 import TabNav from '../../components/ui/TabNav.astro';
 import TabSyncScript from '../../components/ui/TabSyncScript.astro';
 import PresentationCard from '../../components/cards/PresentationCard.astro';
+import UnderConstructionBanner from '../../components/ui/UnderConstructionBanner.astro';
 import { getCollection, render } from 'astro:content';
 
 export async function getStaticPaths() {
@@ -88,6 +89,7 @@ function formatLocation(loc: any): string {
 // Determine if event is upcoming based on start date
 const now = new Date();
 const isUpcoming = event.data.startDate >= now;
+const eventYear = event.data.startDate.getFullYear();
 
 const tabs = [
     { id: 'about', label: 'About' },
@@ -162,6 +164,8 @@ const typeLabels: Record<string, string> = {
             </div>
         </div>
     </section>
+
+    <UnderConstructionBanner show={eventYear !== 2026 && !event.data.validated} />
 
     <!-- Tab Navigation -->
     <div class="tabs-container">

--- a/src/pages/speaking/index.astro
+++ b/src/pages/speaking/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import PageHeader from '../../components/ui/PageHeader.astro';
 import EventCard from '../../components/cards/EventCard.astro';
+import UnderConstructionBanner from '../../components/ui/UnderConstructionBanner.astro';
 import { getCollection } from 'astro:content';
 
 // Get all events
@@ -61,7 +62,7 @@ function formatLocation(loc: any): string {
         <p>Conferences, meetups, and events where I've spoken or will be speaking</p>
     </PageHeader>
 
-    <!-- Upcoming Events -->
+    <UnderConstructionBanner />
     <section class="section">
         <div class="container">
             <h2 class="section-title">Upcoming Events</h2>


### PR DESCRIPTION
…t pages

- Create UnderConstructionBanner component (show prop, defaults true)
- Add 'validated' boolean field to presentations and events schemas
- Show banner on presentations listing and individual pages
- Show banner on speaking/events listing and individual pages
- Show banner on engagement presentation pages
- Suppress banner on 2026 event pages (and their engagements)
- Suppress banner when presentation/event validated: true in frontmatter

To remove banner for a specific page: add 'validated: true' to its frontmatter.
To remove from listing pages: delete the <UnderConstructionBanner /> line.